### PR TITLE
Fixed compdb, tested with autocomplete-clang

### DIFF
--- a/lib/clang-flags.coffee
+++ b/lib/clang-flags.coffee
@@ -37,9 +37,15 @@ getClangFlagsCompDB = (fileName) ->
   if compDBContents != null && compDBContents.length > 0
     compDB = JSON.parse(compDBContents)
     for config in compDB
-      if fileName == path.join config['directory'], config['file']
-        #Find the file here
-        args = args.concat ["-working-directory=#{config['directory']}"]
+      if fileName == config['file']
+        includes = config.command.match(/-I\S*/g);
+        if includes
+            args = args.concat includes
+        system_includes = config.command.match(/-isystem\s*\S*/gi);
+        if system_includes
+            args = args.concat system_includes
+        args = args.concat ["-working-directory=#{searchDir}"]
+        break
   return args
 
 getClangFlagsDotClangComplete = (fileName) ->


### PR DESCRIPTION
Hello Kev. I agree that compdb is in general a better solution than clang_complete. However, I think a full switch to compdb will not be an easy task. Other packages that use project-wide flags will introduce complications. In the meantime, I believe the clang-flags package should support reading include directories from both clang_complete and compile_commands.json files. I changed the compdb portion of the code to do that. It basically parses the compiler flags in the compile_commands.json file, and appends the include directives to the argument list. With this change, both compdb and clang_complete work for the purposes of setting include directories. With this improvement, you can make a new release without commenting out anything -- and everything should work fine.
