### PR TITLE
Updated pathwatcher Version to 3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/Kev/clang-flags",
   "dependencies": {
-    "pathwatcher": "^2.5.0"
+    "pathwatcher": "^3.1.0"
   },
   "devDependencies": {
     "coffee-script": ">= 1.7.1"


### PR DESCRIPTION
pathwatcher Version to 2.5.0 causes [build errors](https://github.com/Kev/clang-flags/issues/6). I have tested this with autocomplete-clang and linter-clang.
