### PR TITLE
Eliminate dependency on pathwatcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   },
   "homepage": "https://github.com/Kev/clang-flags",
   "dependencies": {
-    "pathwatcher": "^3.1.0"
   },
   "devDependencies": {
     "coffee-script": ">= 1.7.1"


### PR DESCRIPTION
Dependency on pathwatcher has caused 'Module version mismatch' problems like https://github.com/yasuyuky/autocomplete-clang/issues/46 
This PR eliminate dependency on pathwatcher. 
