### PR TITLE
Use arguments that start with `-D` from compile_commands.json

### DIFF
--- a/lib/clang-flags.coffee
+++ b/lib/clang-flags.coffee
@@ -47,7 +47,7 @@ getClangFlagsCompDB = (fileName) ->
           singleArgs.push allArgs[i] if allArgs[i][0] == '-' and (not nextArg || nextArg[0] == '-')
           doubleArgs.push allArgs[i] + " " + nextArg if allArgs[i][0] == '-' and nextArg and (nextArg[0] != '-')
         args = singleArgs
-        args.push it for it in doubleArgs when it[0..7] == '-isystem'
+        args.push it for it in doubleArgs when it[0..7] == '-isystem' || it[0..1] == '-D'
         args = args.concat ["-working-directory=#{searchDir}"]
         break
   return args


### PR DESCRIPTION
This change adds arguments to the returned args of
`getClangFlagsCompDB` that start with -D. These flags define symbols
at compile time. Merging this change will improve the precision of
`autocomplete-clang`.

Example: compile this program with `clang -DTST` and it will compile
correctly. The change allows `autocomplete-clang` to see that `TST`
was actually define, it will not emit a warning then.

```

void foo(int x) {}

int main(int argc, char const *argv[]) {
  foo(12);
  return 0;
}
```

I
