### PR TITLE
Handle double args intact

### DIFF
--- a/lib/clang-flags.coffee
+++ b/lib/clang-flags.coffee
@@ -46,9 +46,9 @@ getClangFlagsCompDB = (fileName) ->
           nextArg = allArgs[i+1]
           # work out which are standalone arguments, and which take a parameter
           singleArgs.push allArgs[i] if allArgs[i][0] == '-' and (not nextArg || nextArg[0] == '-')
-          doubleArgs.push allArgs[i] + " " + nextArg if allArgs[i][0] == '-' and nextArg and (nextArg[0] != '-')
+          doubleArgs.push [allArgs[i], nextArg] if allArgs[i][0] == '-' and nextArg and (nextArg[0] != '-')
         args = singleArgs
-        args.push it for it in doubleArgs when it[0..7] == '-isystem'
+        args = args.concat it for it in doubleArgs when it[0][0..7] == '-isystem'
         args = args.concat ["-working-directory=#{searchDir}"]
         break
   return args


### PR DESCRIPTION
Current code join arg like ["-isystem", "/usr/..."] to ["-isystem /usr/..."]. This merging cause clang to fail to parse the path properly.

To reproduce:
$ clang -xc --verbose -c "-isystem /usr" /dev/null
clang version 4.0.0 (tags/RELEASE_400/final)
Target: x86_64-pc-linux-gnu
...
clang -cc1 version 4.0.0 based upon LLVM 4.0.0 default target x86_64-pc-linux-gnu
ignoring nonexistent directory " /usr"
...

As shown in the output, it tries to lookup " /usr", instead of "/usr".

Clang-3.8.0 also behave as the same: https://wandbox.org/permlink/Iyxjqbg6tE9Nr5qs

Thus, the commit properly handle such double argument, not joining them with space.